### PR TITLE
Position background rect at 0,0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Updated build script (`addons/godot_xterm/native/build.sh`). Git submodules will now be initialized if they haven't already. Moved nix-shell related stuff to a seperate shell.nix file so the same build command can be used on all Linux based OSes.
+- Positioned background rect at 0,0 so it is no longer offset if a margin is added when Terminal is a child of a Container node.
 
 ## [1.0.0] - 2020-10-05
 ### Added

--- a/addons/godot_xterm/native/src/terminal.cpp
+++ b/addons/godot_xterm/native/src/terminal.cpp
@@ -371,7 +371,7 @@ void Terminal::_draw()
 		return;
 
 	/* Draw the full terminal rect background */
-	draw_rect(get_rect(), get_color("Background", "Terminal"));
+	draw_rect(Rect2(Vector2(0, 0), get_rect().size), get_color("Background", "Terminal"));
 
 	for (int row = 0; row < rows; row++)
 	{


### PR DESCRIPTION
This is important when terminal is a child of a Container node and we
set the margin properties, otherwise the background rect is drawn with
an offset.

Before:
![2020-10-16-121653_568x213_scrot](https://user-images.githubusercontent.com/3696783/96216533-c215d600-0faa-11eb-9969-4f42ad3c7238.png)

After:
![2020-10-16-121731_571x216_scrot](https://user-images.githubusercontent.com/3696783/96216543-c80bb700-0faa-11eb-8f8f-f48140ba5dd2.png)

Background colored white in screenshots for visibility.
