### PR TITLE
Update travis-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Version](https://img.shields.io/badge/version-0.1.0-orange.svg)
 ![Godot Version](https://img.shields.io/badge/godot-3.2+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-[![Build Status](https://travis-ci.org/lihop/godot-xterm.svg?branch=master)](https://travis-ci.org/lihop/godot-xterm)
+[![Build Status](https://travis-ci.com/lihop/godot-xterm.svg?branch=master)](https://travis-ci.com/lihop/godot-xterm)
 
 Terminal emulator for Godot using GDNative and [libtsm](https://github.com/Aetf/libtsm).
 


### PR DESCRIPTION
Moved from travis-ci.org -> travis-ci.com.