### PR TITLE
Update github actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,56 +7,85 @@ on:
     branches: [ master ]
 
 jobs:
-  build-nixos:
+  docker:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [ build-nixos, build-archlinux, build-ubuntu ]
     steps:
       - uses: actions/checkout@v2
-      - name: Build for supported platforms on NixOS
-        run: docker-compose run build-nixos
-  build-archlinux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build for supported platforms on Arch Linux
-        run: docker-compose run build-archlinux
-  build-ubuntu:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build for supported platforms on Ubuntu
-        run: docker-compose run build-ubuntu
-  build-windows:
-    runs-on: windows-latest
+      - name: Build inside docker container
+        run: docker-compose run ${{ matrix.service }}
+
+  release-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        platform: [ linux, osx, windows ]
+        bits: [ 64, 32 ]
+        include:
+          - platform: linux
+            os: ubuntu-latest
+          - platform: osx
+            os: macos-latest
+          - platform: windows
+            os: windows-latest
+        exclude:
+          - platform: osx
+            bits: 32 # Only 64-bit supported on macOS.
+          - platform: windows
+            bits: 32 # TODO: Enable 32-bit build on windows-latest.
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: ilammy/msvc-dev-cmd@v1
-      - name: Install SCons software construction tool
+
+      - name: Get godot-cpp submodule commit hash
+        shell: bash
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+        run: |
+          echo ::set-env name=GODOT_CPP_COMMIT_HASH::$(git ls-tree HEAD addons/godot_xterm/native/external/godot-cpp -l | cut -d\  -f3)
+      - name: Cache godot-cpp bindings
+        uses: actions/cache@v2
+        id: cache
+        env:
+          cache-name: cache-godot-cpp
+        with:
+          path: addons/godot_xterm/native/external/godot-cpp
+          key: godot-cpp-${{ matrix.platform }}-release-${{ matrix.bits }}-${{ env.GODOT_CPP_COMMIT_HASH }}
+
+      - name: Install ubuntu build dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo apt-get install -y scons gcc-multilib g++-multilib
+
+      - name: Install additional macos build dependencies
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: brew install scons
+
+      - name: Install additional windows build dependencies
+        if: ${{ matrix.os == 'windows-latest' }}
         run: choco install python3 && python -m pip install scons
-      - name: Build for Windows 64-bit using MSVC
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ matrix.os == 'windows-latest' }}
+
+      - name: Build godot-cpp bindings
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           cd addons/godot_xterm/native/external/godot-cpp
-          scons platform=windows target=release bits=64 generate_bindings=yes
-          cd ../../
-          scons platform=windows target=release bits=64
-      - uses: actions/upload-artifact@v2
-        with:
-          name: bin
-          path: addons/godot_xterm/native/bin/*.dll
-  build-macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install SCons software construction tool
-        run: brew install scons
-      - name: Buid for macOS 64-bit using llvm
+          scons platform=${{ matrix.platform }} target=release bits=${{ matrix.bits }} generate_bindings=yes -j2
+
+      - name: Build libgodot-xterm
         run: |
           cd addons/godot_xterm/native
-          scons platform=osx target=release bits=64
-      - uses: actions/upload-artifact@v2
+          scons platform=${{ matrix.platform }} target=release bits=${{ matrix.bits }} -j2
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
         with:
           name: bin
-          path: addons/godot_xterm/native/bin/*.dylib
+          path: |
+            addons/godot_xterm/native/bin/*.so
+            addons/godot_xterm/native/bin/*.dylib
+            addons/godot_xterm/native/bin/*.dll
+

--- a/addons/godot_xterm/native/SConstruct
+++ b/addons/godot_xterm/native/SConstruct
@@ -69,11 +69,6 @@ Help(opts.GenerateHelpText(env))
 # Add PATH to environment so scons can find commands such as g++, etc.
 env.AppendENVPath('PATH', os.getenv('PATH'))
 
-# Generate godot-cpp bindings.
-# Options such as platform, target, etc. will be forwarded to the godot-cpp SConscript.
-ARGUMENTS['generate_bindings'] = True
-SConscript('external/godot-cpp/SConstruct')
-
 
 # Compile for Linux.
 if env['platform'] == 'linux':

--- a/addons/godot_xterm/native/build.sh
+++ b/addons/godot_xterm/native/build.sh
@@ -26,24 +26,10 @@ if [ ! -d "${GODOT_CPP_DIR}" ]; then
 	git submodule update --init --recursive -- $GODOT_CPP_DIR
 fi
 
+# Build godot-cpp bindings.
+cd ${GODOT_CPP_DIR}
+scons generate_bindings=yes -j$(nproc)
 
 # Build libgodot-xterm.
 cd ${NATIVE_DIR}
-case $1 in
-	"release-all")
-		# Cross-compile release build for all platforms.
-		scons platform=linux bits=64 target=release -j$(nproc)
-		if [ $IN_NIX_SHELL ]; then
-			nix-shell --pure --argstr system i686-linux --run "NIX_PATH=${NIX_PATH} scons platform=linux bits=32 target=release -j$(nproc)"
-		else
-			scons platform=linux bits=32 target=release -j$(nproc)
-		fi
-		scons platform=windows bits=64 target=release -j$(nproc)
-		#scons platform=windows bits=32 target=release -j$(nproc)
-		#scons platform=osx bits=64 target=release -j$(nproc)
-		;;
-	*)
-		# Default: Compile debug build for the current platform.
-		scons -j$(nproc)
-		;;
-esac
+scons -j$(nproc)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,14 @@ services:
     build:
       context: .
       dockerfile: ./dockerfiles/archlinux
-    command: /src/addons/godot_xterm/native/build.sh release-all
+    command: /src/addons/godot_xterm/native/build.sh
   build-nixos:
     build:
       context: .
       dockerfile: ./dockerfiles/nixos
-    command: /src/addons/godot_xterm/native/build.sh release-all
+    command: /src/addons/godot_xterm/native/build.sh
   build-ubuntu:
     build:
       context: .
       dockerfile: ./dockerfiles/ubuntu
-    command: /src/addons/godot_xterm/native/build.sh release-all
+    command: /src/addons/godot_xterm/native/build.sh


### PR DESCRIPTION
- Uses matrix so that build steps don't need to be defined multiple
  times.
- Caches godot-cpp bindings, so they only need to be built when the
  submodule version changes.
- Uploads build artifacts for linux 32/64-bit, windows 64-bit and macOS
  64-bit.