### PR TITLE
Provide correct arguments to execvp

### DIFF
--- a/addons/godot_xterm/native/src/pseudoterminal.cpp
+++ b/addons/godot_xterm/native/src/pseudoterminal.cpp
@@ -1,7 +1,8 @@
 #include "pseudoterminal.h"
-#include <unistd.h>
+#include <libgen.h>
 #include <sys/wait.h>
 #include <termios.h>
+#include <unistd.h>
 
 // Platform specific includes.
 #if defined(PLATFORM_LINUX)
@@ -77,7 +78,8 @@ void Pseudoterminal::process_pty()
         putenv(colortermenv);
 
         char *shell = getenv("SHELL");
-        execvp(shell, NULL);
+        char *argv[] = { basename(shell), NULL };
+        execvp(shell, argv);
     }
     else
     {


### PR DESCRIPTION
Previously no arguments were provided, but by convention argv[0] should
be the name of the program.

Providing this argumens enables Psuedoterminal node to work on macOS.