### PR TITLE
Request redraw after write if terminal visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#51][i51]: Fixed issue where terminal would lose focus on Tab/Arrow key presses
   when in a scene with other input nodes. Thanks [@ConteZero] for reporting.
+- [#53][i53]: Fixed issue where terminal was not updating when there was no GUI
+  activity. Thanks [@ConteZero] for providing feedback on this issue.
 
+[i53]: https://github.com/lihop/godot-xterm/issues/53
 [i51]: https://github.com/lihop/godot-xterm/issues/51
 [@ConteZero]: https://github.com/ConteZero
 

--- a/addons/godot_xterm/editor_plugins/terminal/editor_terminal.gd
+++ b/addons/godot_xterm/editor_plugins/terminal/editor_terminal.gd
@@ -4,7 +4,6 @@ extends "../../terminal.gd"
 signal exited(exit_code, signum)
 
 var editor_settings: EditorSettings
-var timer := Timer.new()
 
 onready var pty = $PTY
 
@@ -50,20 +49,6 @@ func _ready():
 		}
 	)
 	_native_terminal._update_theme()
-
-	# In editor _process is not called continuously unless the "Update Continuously"
-	# editor setting is enabled. This setting is disabled by default and uses 100%
-	# of one core when enabled, so best to leave it off and use a timer instead.
-	add_child(timer)
-	timer.wait_time = 0.025
-	timer.connect("timeout", self, "_poll")
-	timer.start()
-
-
-func _poll():
-	if pty and pty.has_method("get_master"):
-		pty.get_master().poll()
-		update()
 
 
 func _input(event):

--- a/addons/godot_xterm/terminal.gd
+++ b/addons/godot_xterm/terminal.gd
@@ -83,6 +83,10 @@ func write(data) -> void:
 	# Will be cleared when _flush() is called after VisualServer emits the "frame_pre_draw" signal.
 	_buffer.push_back(data)
 
+	# Ensure redraw is requested if terminal is visible.
+	if visible:
+		update()
+
 
 func _flush():
 	for data in _buffer:


### PR DESCRIPTION
Ensures a redraw is requested after writing to terminal, otherwise
terminal will not be updated if there are no other redraw requests.

Fixes #53.