### PR TITLE
feat: add get_cursor_pos()

### DIFF
--- a/addons/godot_xterm/native/src/terminal.cpp
+++ b/addons/godot_xterm/native/src/terminal.cpp
@@ -290,6 +290,8 @@ void Terminal::_register_methods() {
   register_method("sb_reset", &Terminal::sb_reset);
   register_method("clear_sb", &Terminal::clear_sb);
 
+  register_method("get_cursor_pos", &Terminal::get_cursor_pos);
+
   register_method("start_selection", &Terminal::start_selection);
   register_method("select_to_pointer", &Terminal::select_to_pointer);
   register_method("reset_selection", &Terminal::reset_selection);
@@ -633,6 +635,11 @@ void Terminal::sb_reset() {
 void Terminal::clear_sb() {
   tsm_screen_clear_sb(screen);
   update();
+}
+
+Vector2 Terminal::get_cursor_pos() {
+  return Vector2(tsm_screen_get_cursor_x(screen),
+                 tsm_screen_get_cursor_y(screen));
 }
 
 void Terminal::start_selection(Vector2 position) {

--- a/addons/godot_xterm/native/src/terminal.h
+++ b/addons/godot_xterm/native/src/terminal.h
@@ -60,6 +60,8 @@ public:
   void sb_reset();
   void clear_sb();
 
+  Vector2 get_cursor_pos();
+
   void start_selection(Vector2 position);
   void select_to_pointer(Vector2 position);
   void reset_selection();

--- a/addons/godot_xterm/terminal.gd
+++ b/addons/godot_xterm/terminal.gd
@@ -71,6 +71,10 @@ func get_rows() -> int:
 	return _rows
 
 
+func get_cursor_pos() -> Vector2:
+	return _native_terminal.get_cursor_pos()
+
+
 func write(data) -> void:
 	assert(
 		data is PoolByteArray or data is String,

--- a/test/integration/terminal.test.gd
+++ b/test/integration/terminal.test.gd
@@ -33,6 +33,21 @@ func test_bell_cooldown() -> void:
 	assert_signal_emit_count(terminal, "bell", 2)
 
 
+func test_cursor_get_pos_initially_0_0() -> void:
+	assert_eq(terminal.get_cursor_pos(), Vector2(0, 0))
+
+
+func test_cursor_get_pos_increments_immediately() -> void:
+	terminal.write(" ")
+	assert_eq(terminal.get_cursor_pos(), Vector2(1, 0))
+
+
+func test_cursor_get_pos_increments_eventually() -> void:
+	terminal.write(" ")
+	yield(yield_to(get_tree(), "idle_frame", 1), YIELD)
+	assert_eq(terminal.get_cursor_pos(), Vector2(1, 0))
+
+
 func test_writing_random_data_to_terminal_does_not_crash_application():
 	add_child_autofree(preload("res://test/scenes/write_random.tscn").instance())
 	yield(yield_frames(5, "Writing random data to terminal"), YIELD)


### PR DESCRIPTION
Related to #72.

@diggernet Here's a straightforward PR to expose the current cursor position. However, I noticed something interesting when testing:
```gdscript
  terminal.write(" ")
  yield(yield_to(get_tree(), "idle_frame", 1), YIELD)
  assert_eq(terminal.get_cursor_pos(), Vector2(1, 0))
```
passes! but
```gdscript
  terminal.write(" ")
  assert_eq(terminal.get_cursor_pos(), Vector2(1, 0))
```
does not!

It seems unintuitive that the cursor position would not update immediately after calling `write(" ")`. After checking, it's the `write()` method in `terminal.gd` that is asynchronous, not the `write()` method in `terminal.cpp`, like I suggested in https://github.com/lihop/godot-xterm/issues/72#issuecomment-1925605466 (it's been a while since I worked on the codebase :sweat_smile:).

I'm tempted to hold off on adding `get_cursor_pos()` for now, as not updating immediately too unintuitive.

Here is the problem area:
https://github.com/lihop/godot-xterm/blob/b575895aa782ceaf6b23d9447518bdfcb9332a6b/addons/godot_xterm/terminal.gd#L74-L92

Modifying it as follows:
```diff
diff --git a/addons/godot_xterm/terminal.gd b/addons/godot_xterm/terminal.gd
index 3e5de5f..af947e8 100644
--- a/addons/godot_xterm/terminal.gd
+++ b/addons/godot_xterm/terminal.gd
@@ -88,14 +88,16 @@ func write(data) -> void:
        if visible:
                update()
 
-
-func _flush():
        for data in _buffer:
                _native_terminal.write(data if data is PoolByteArray else data.to_utf8())
                _native_terminal.update()
        _buffer.clear()
 
 
+func _flush():
+       _native_terminal.update();
+
+
 func clear() -> void:
        var initial_size = _native_terminal.rect_size
        _native_terminal.rect_size.y = _native_terminal.cell_size.y
```
allows the `get_cursor_pos()` test to pass, but causes another test [(test_bell)](https://github.com/lihop/godot-xterm/blob/b575895aa782ceaf6b23d9447518bdfcb9332a6b/test/integration/terminal.test.gd#L14-L22) to fail.

There is definitely a reason why it was done that way, but figuring out why and how to unpick it will take a bit of work.

I would like to note the Godot 4 version is turning out to be quite a bit simpler, with _everything_ implemented in C++. The Godot 3 version is a bit of a mess with it's double handling in both `terminal.gd` and `terminal.cpp`.