### PR TITLE
feat(theme)!: set a default theme

### DIFF
--- a/addons/godot_xterm/native/src/constants.cpp
+++ b/addons/godot_xterm/native/src/constants.cpp
@@ -15,6 +15,8 @@ const char* Terminal::COLOR_NAMES[18] = {
     "foreground_color", "background_color",
 };
 
+// These match the font names of RichTextLabel: https://docs.godotengine.org/en/4.2/classes/class_richtextlabel.html.
+// They are all expected to be monospace fonts.
 const char* Terminal::FONT_TYPES[4] = {
     "normal_font", "bold_font", "italics_font", "bold_italics_font",
 };

--- a/addons/godot_xterm/native/src/terminal.h
+++ b/addons/godot_xterm/native/src/terminal.h
@@ -177,6 +177,8 @@ namespace godot
 
     typedef std::function<int(struct tsm_screen*, char**)> ScreenCopyFunction;
     String _copy_screen(ScreenCopyFunction func);
+
+    void set_default_theme_items();
   };
 
 } // namespace godot

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ myst_substitutions = {
   # Godot classes.
   'AudioStream': '[AudioStream](' + godot_class.format('audiostream.html') + ')',
   'CanvasItem': '[CanvasItem](' + godot_class.format('canvasitem.html') + ')',
+  'CodeEdit': '[CodeEdit](' + godot_class.format('code_edit.html') + ')',
   'Color': '[Color](' + godot_class.format('color.html') + ')',
   'Control': '[Control](' + godot_class.format('control.html') + ')',
   'Error': '[Error](' + godot_class.format('%40globalscope.html#enum-globalscope-error') + ')',
@@ -57,6 +58,7 @@ myst_substitutions = {
   'PoolByteArray': '[PoolByteArray](' + godot_class.format('poolbytearray.html') + ')',
   'PoolStringArray': '[PoolStringArray](' + godot_class.format('poolstringarray.html') + ')',
   'String': '[String](' + godot_class.format('string.html') + ')',
+  'TextEdit': '[TextEdit](' + godot_class.format('text_edit.html') + ')',
   'Vector2': '[Vector2](' + godot_class.format('vector2.html') + ')',
   'bool': '[bool](' + godot_class.format('bool.html') + ')',
   'float': '[float](' + godot_class.format('float.html') + ')',

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ Primarily developed and tested on Linux, it also supports macOS with partial sup
 :caption: Table of Contents
 
 introduction
+themes
 setup/index
 api/index
 CHANGELOG

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,55 @@
+# Themes
+
+This section explains how you can go about themeing the {{Terminal}} node.
+
+## Default
+
+If you add a {{Terminal}} node to your scene without any themes or theme overrides, then the default theme will apply.
+This default theme is based on the default theme that Godot uses for the {{TextEdit}} and {{CodeEdit}} nodes.
+
+### Font
+
+[JetBrains Mono](https://www.jetbrains.com/lp/mono/) is the default font.
+This is the same default font as the Godot code editor (since version 4).
+It is not included with the default theme, so we bundle it separately.
+
+:::{caution}
+Only the regular version of the font is included. The **bold**, _italic_, and **_bold italic_** variants are not.
+If you want these, you'll need to include them in a custom theme.
+:::
+:::{error}
+This font has support for ligatures (see: [Ligatures for Code](https://github.com/JetBrains/JetBrainsMono?tab=readme-ov-file#ligatures-for-code)).
+While the engine supports this feature, GodotXterm currently does not, and there are no immediate plans to support it.
+:::
+
+The default font size is 16.
+
+### Colors
+
+GodotXterm uses the same default font color and background color as Godot's {{TextEdit}} and {{CodeEdit}} nodes.
+
+:::{note}
+The default background color of Control nodes is intentionally traslucent.
+See [the discussion](https://github.com/godotengine/godot/pull/51159#issuecomment-891126656) on the Godot GitHub repo about this.
+:::
+
+The default ANSI colors are the same as [the xterm defaults](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors).
+
+| FG  | BG  | Color Name     | Theme Item Name | Hex Code Value | Color Block                            |
+| --- | --- | -------------- | --------------- | -------------- | -------------------------------------- |
+| 30  | 40  | Black          | ansi_0_color    | `#000000`      | <span style="color: #000000">██</span> |
+| 31  | 41  | Red            | ansi_1_color    | `#CD0000`      | <span style="color: #CD0000">██</span> |
+| 32  | 42  | Green          | ansi_2_color    | `#00CD00`      | <span style="color: #00CD00">██</span> |
+| 33  | 43  | Yellow         | ansi_3_color    | `#CDCD00`      | <span style="color: #CDCD00">██</span> |
+| 34  | 44  | Blue           | ansi_4_color    | `#0000EE`      | <span style="color: #0000EE">██</span> |
+| 35  | 45  | Magenta        | ansi_5_color    | `#CD00CD`      | <span style="color: #CD00CD">██</span> |
+| 36  | 46  | Cyan           | ansi_6_color    | `#00CDCD`      | <span style="color: #00CDCD">██</span> |
+| 37  | 47  | White          | ansi_7_color    | `#E5E5E5`      | <span style="color: #E5E5E5">██</span> |
+| 90  | 100 | Bright Black   | ansi_8_color    | `#7F7F7F`      | <span style="color: #7F7F7F">██</span> |
+| 91  | 101 | Bright Red     | ansi_9_color    | `#FF0000`      | <span style="color: #FF0000">██</span> |
+| 92  | 102 | Bright Green   | ansi_10_color   | `#00FF00`      | <span style="color: #00FF00">██</span> |
+| 93  | 103 | Bright Yellow  | ansi_11_color   | `#FFFF00`      | <span style="color: #FFFF00">██</span> |
+| 94  | 104 | Bright Blue    | ansi_12_color   | `#5C5CFF`      | <span style="color: #5C5CFF">██</span> |
+| 95  | 105 | Bright Magenta | ansi_13_color   | `#FF00FF`      | <span style="color: #FF00FF">██</span> |
+| 96  | 106 | Bright Cyan    | ansi_14_color   | `#00FFFF`      | <span style="color: #00FFFF">██</span> |
+| 97  | 107 | Bright White   | ansi_15_color   | `#FFFFFF`      | <span style="color: #FFFFFF">██</span> |


### PR DESCRIPTION
Adds 'Terminal' type to the default theme. Sets values to those similar to CodeEdit and TextEdit. Colors default to Xterm defaults.