### PR TITLE
Add select method to Terminal

### DIFF
--- a/addons/godot_xterm/native/src/terminal.cpp
+++ b/addons/godot_xterm/native/src/terminal.cpp
@@ -648,9 +648,11 @@ String Terminal::_copy_screen(ScreenCopyFunction func) {
 	char *out;
 	PackedByteArray data;
 
-	data.resize(func(screen, &out));
-	memcpy(data.ptrw(), out, data.size());
-	std::free(out);
+	data.resize(std::max(func(screen, &out), 0));
+	if (data.size() > 0) {
+		memcpy(data.ptrw(), out, data.size());
+		std::free(out);
+	}
 
 	return data.get_string_from_utf8();
 }

--- a/addons/godot_xterm/native/src/terminal.h
+++ b/addons/godot_xterm/native/src/terminal.h
@@ -74,6 +74,8 @@ namespace godot
 
     void clear();
 
+    void select(const int p_from_line, const int p_from_column, const int p_to_line, const int p_to_column);
+
     String copy_all();
     String copy_selection();
     void set_copy_on_selection(const bool p_enable);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/lihop/godot-xterm/compare/v2.2.0...HEAD)
 
+### Added
+
+- Added select() method to Terminal.
+
 ### Changed
 
 - Custom export templates are no longer required when exporting to HTML5 from Godot v3.5.x.

--- a/docs/api/terminal.md
+++ b/docs/api/terminal.md
@@ -42,14 +42,15 @@ For example if the string `"\u001b[38;2;0;255;0;mA"` was written to the terminal
 
 ## Methods
 
-| Returns    | Signature                                                           |
-| ---------- | ------------------------------------------------------------------- |
-| void       | [clear](#mthd-clear) **( )**                                        |
-| {{String}} | [copy_all](#mthd-copy_all) **( )**                                  |
-| {{String}} | [copy_selection](#mthd-copy_selection) **( )**                      |
-| {{int}}    | [get_cols](#mthd-get_cols) **( )**                                  |
-| {{int}}    | [get_rows](#mthd-get_rows) **( )**                                  |
-| void       | [write](#mthd-write) **(** {{String}}\|{{PoolByteArray}} data **)** |
+| Returns    | Signature                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------ |
+| void       | [clear](#mthd-clear) **( )**                                                                                 |
+| {{String}} | [copy_all](#mthd-copy_all) **( )**                                                                           |
+| {{String}} | [copy_selection](#mthd-copy_selection) **( )**                                                               |
+| {{int}}    | [get_cols](#mthd-get_cols) **( )**                                                                           |
+| {{int}}    | [get_rows](#mthd-get_rows) **( )**                                                                           |
+| void       | [select](#mthd-select) **(** {{int}} from_line, {{int}} from_column, {{int}} to_line {{int}} to_column **)** |
+| void       | [write](#mthd-write) **(** {{String}}\|{{PoolByteArray}} data **)**                                          |
 
 ## Signals
 
@@ -188,6 +189,12 @@ It will automatically update according to the terminal's rect_size and theme's f
 Returns the height of the terminal in characters.
 When using a monospace font, this is the number of visible characters that can fit from the top of the terminal to the bottom in a single column.
 It will automatically update according to the terminal's rect_size and theme's font size.
+
+<hr id="mthd-select" />
+
+void **select** **(** {{int}} from_line, {{int}} from_column, {{int}} to_line, {{int}} to_column **)**
+
+Perform selection, from line/column to line/column.
 
 <hr id="mthd-write" />
 

--- a/test/test_terminal.gd
+++ b/test/test_terminal.gd
@@ -222,6 +222,9 @@ class TestCopy:
 		subject.write(text)
 		assert_string_contains(subject.copy_all(), text)
 
+	func test_copy_selection_when_nothing_selected():
+		assert_eq(subject.copy_selection(), "")
+
 
 class TestClear:
 	extends TerminalTest


### PR DESCRIPTION
Adds select() method to terminal. Behaves the same as TextEdit's select() method.
Fixes copy_selection() bug when called and nothing selected.