### PR TITLE
fix socat_terminal example

### DIFF
--- a/examples/socat_terminal/socat_terminal.gd
+++ b/examples/socat_terminal/socat_terminal.gd
@@ -19,6 +19,7 @@ func _ready():
 
 
 func _process(delta):
+	_stream.poll()
 	match _stream.get_status():
 		StreamPeerTCP.STATUS_NONE, StreamPeerTCP.STATUS_CONNECTING:
 			_timeout -= 1

--- a/examples/socat_terminal/socat_terminal.tscn
+++ b/examples/socat_terminal/socat_terminal.tscn
@@ -11,3 +11,5 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_rw2ub")
 script = ExtResource("1")
+
+[connection signal="data_sent" from="." to="." method="_on_Terminal_data_sent"]


### PR DESCRIPTION
* Godot 4.x seems to require call StreamPeerTCP.poll
* add missing signal connection (data from terminal to network)