### PR TITLE
fix: delete single char on backspace in PowerShell

### DIFF
--- a/addons/godot_xterm/native/src/terminal.cpp
+++ b/addons/godot_xterm/native/src/terminal.cpp
@@ -116,6 +116,7 @@ Terminal::Terminal() {
         ERR_PRINT("Failed to create tsm vte.");
     }
     tsm_vte_set_bell_cb(vte, &Terminal::_bell_cb, this);
+    tsm_vte_set_backspace_sends_delete(vte, true);
 
     initialize_input();
     initialize_rendering();


### PR DESCRIPTION
PowerShell expects DEL (0x7F) for backspace, not BS (0x08). Most Unix/Linux shells accept both, but PowerShell is strict about DEL. The PTY layer already configures VERASE=0x7F (the "erase character" that the shell uses for backspace), so the terminal emulator should match by sending DEL.

Without this fix, PowerShell interprets BS as a word-deletion command.

Closes #126.